### PR TITLE
Feature: Advanced DynamicActionMergers

### DIFF
--- a/src/libHeaven/Actions/DynamicActionMerger.cpp
+++ b/src/libHeaven/Actions/DynamicActionMerger.cpp
@@ -1,6 +1,8 @@
 /*
  * libHeaven - A Qt-based ui framework for strongly modularized applications
- * Copyright (C) 2012-2013 Sascha Cunz <sascha@babbelbox.org>
+ * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ *
+ * (C) Sascha Cunz <sascha@macgitver.org>
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License (Version 2) as published by the Free Software Foundation.
@@ -21,6 +23,63 @@
 
 namespace Heaven
 {
+
+    /**
+     * @enum        MergerMode
+     * @ingroup     Actions
+     * @brief       Operation modes of a DynamicActionMerger
+     *
+     * @var         MergerMode::DAMergerCallback
+     *              This is a _active_ mode. Every time that the framework internally rebuilds the
+     *              actions, a call back slot is invoked. It's task is to setup a list of actions
+     *              that the framework will use in the place of the DynamicActionMerger.
+     *
+     * @var         MergerMode::DAMergerAdvancedList
+     *              The advanced mode is more _passive_. The owner installs a list of actions or
+     *              key/value pairs into the DAM and this list will be used in the place of the
+     *              DynamicActionMerger.
+     *
+     * @enum        MergerActionLifetime
+     * @ingroup     Actions
+     * @brief       Lifetime of an action inside a DynamicActionMerger
+     *
+     * @var         MergerActionLifetime::DAMergerActionUserControlled
+     *              The lift itme of the action is defined by the consumer. The DynamicActionMerger
+     *              will not delete this action.
+     *
+     * @var         MergerActionLifetime::DAMergerActionMergerControlled
+     *              The lift time of this action is managed by the DynamicActionMerger. It will
+     *              delete the action as the replacement list is repopulated.
+     *
+     * @class       DynamicActionMerger
+     * @ingroup     Actions
+     * @brief       Add dynamic actions to an action structure
+     *
+     * A DynamicActionMerger (DAM) is used to populate a structure with dynamic actions. It has two
+     * modes of operation:
+     *
+     * -   __Callback__:
+     *     This is a _active_ mode. Every time that the framework internally rebuilds the actions, a
+     *     call back slot is invoked. It's task is to setup a list of actions that the framework
+     *     will use in the place of the DynamicActionMerger.
+     *
+     * -   __Advanced__:
+     *     The advanced mode is more _passive_. The owner installs a list of actions or key/value
+     *     pairs into the DAM and this list will be used in the place of the DynamicActionMerger.
+     *
+     * The mode can be set with setMode(), the merger slot can be set via setMergerSlot().
+     *
+     * As with all UiObject classes, a DAM is typically not created directly but rather through the
+     * help of a @ref md_HID "HID file".
+     *
+     * @fn          DynamicActionMerger::entryTriggered( QVariant value )
+     * @brief       Emitted when an action got triggered
+     *
+     * @param[in]   value   The value that was used to add the action that has been triggered.
+     *
+     * This signal is emitted when an action got triggered.
+     *
+     */
 
     DynamicActionMergerPrivate::DynamicActionMergerPrivate( DynamicActionMerger* owner )
         : UiObjectPrivate( owner )
@@ -78,11 +137,28 @@ namespace Heaven
         }
     }
 
+    /**
+     * @brief       Constructor
+     *
+     * @param[in]   parent      The parent in QObject object hierarchy.
+     *
+     * Sets the mode to DAMergerCallback.
+     *
+     */
     DynamicActionMerger::DynamicActionMerger( QObject* parent )
         : UiObject( parent, new DynamicActionMergerPrivate( this ) )
     {
     }
 
+    /**
+     * @brief       Rebuild the action list
+     *
+     * This slot is either involked internally or can be explicitly called from consumer code.
+     *
+     * If the current mode() is DAMergerCallback, the internal action list is cleared and the merger
+     * slot is invoked.
+     *
+     */
     void DynamicActionMerger::triggerRebuild()
     {
         UIOD(DynamicActionMerger);
@@ -99,18 +175,53 @@ namespace Heaven
         }
     }
 
+    /**
+     * @brief       Set the merger slots
+     *
+     * @param[in]   szSlot      An Qt-encoded slot signature. Use the `SLOT()` macro for encoding.
+     *
+     * The merger slot can also be set through the HID-Property `Merger`.
+     *
+     */
     void DynamicActionMerger::setMergerSlot( const char *szSlot )
     {
         UIOD(DynamicActionMerger);
         d->mMergerSlot = szSlot;
     }
 
+    /**
+     * @brief       Clear the internal action list
+     *
+     * For the mode() DAMergerCallback, this happens automatically. For DAMergerAdvancedList the
+     * consumer code might want to clear out the list when it shall be regenerated from scratch.
+     *
+     */
     void DynamicActionMerger::clear()
     {
         UIOD(DynamicActionMerger);
         d->freeActionList();
     }
 
+    /**
+     * @brief       Add an action to the internal action list
+     *
+     * @param[in]   act         The QAction to add. If you specifiy `NULL` for this parameter, the
+     *                          value will be converted into a string and an action will be created.
+     *                          This also means that lifeTime will be implicitly set to
+     *                          DAMergerActionMergerControlled.
+     *
+     * @param[in]   value       A `QVariant` that will be used as parameter to the entryTriggered()
+     *                          signal when this action gets triggered.
+     *
+     * @param[in]   lifeTime    Describes the ownership of this action. The default value
+     *                          (DAMergerActionUserControlled) means that the user is responsible
+     *                          for handling destruction of the action.
+     *                          DAMergerActionMergerControlled instead means that the merger will
+     *                          take ownership of the action and delete it when the action list is
+     *                          cleared the next time. This also causes the Merger to reparent the
+     *                          action to itself.
+     *
+     */
     void DynamicActionMerger::addAction( QAction* act, const QVariant& value,
                                          MergerActionLifetime lifeTime )
     {
@@ -138,6 +249,15 @@ namespace Heaven
         d->mActions.append( le );
     }
 
+    /**
+     * @brief       Add the contents of a QStringList to the internal action list
+     *
+     * @param[in]   list    The QStringList to add.
+     *
+     * Each element of the string list will be used as display _and_ as value to be emitted from the
+     * entryTriggered() singal.
+     *
+     */
     void DynamicActionMerger::addStringList( const QStringList& list )
     {
         foreach( QString s, list )
@@ -146,12 +266,29 @@ namespace Heaven
         }
     }
 
+    /**
+     * @brief       Add an action to the merger.
+     *
+     * @param[in]   display     String to be used as display for the action.
+     *
+     * @param[in]   value       A `QVariant` that will be used as parameter to the entryTriggered()
+     *                          signal when this action gets triggered.
+     *
+     * The action will be owned by the Merger.
+     *
+     */
     void DynamicActionMerger::addAction( const QString& display, const QVariant& value )
     {
         QAction* act = new QAction( display, this );
         addAction( act, value, DAMergerActionMergerControlled );
     }
 
+    /**
+     * @brief       Add a separator action to the internal action list
+     *
+     * The separator will be owned by the Merger and deleted as appropiate.
+     *
+     */
     void DynamicActionMerger::addSeparator()
     {
         UIOD(DynamicActionMerger);
@@ -163,6 +300,13 @@ namespace Heaven
         d->mActions.append( le );
     }
 
+    /**
+     * @brief       Set the merger mode
+     *
+     * @param[in]   mode    The new mode to set.
+     *
+     * After setting the merger mode to @a mode, the action list is cleared.
+     */
     void DynamicActionMerger::setMode( MergerMode mode )
     {
         UIOD(DynamicActionMerger);
@@ -170,6 +314,12 @@ namespace Heaven
         clear();
     }
 
+    /**
+     * @brief       Get current merger mode
+     *
+     * @return      The MergerMode that this DAM uses to populate the list of actions.
+     *
+     */
     MergerMode DynamicActionMerger::mode() const
     {
         UIOD(const DynamicActionMerger);

--- a/src/libHeaven/Actions/DynamicActionMerger.hpp
+++ b/src/libHeaven/Actions/DynamicActionMerger.hpp
@@ -28,7 +28,7 @@ class QAction;
 namespace Heaven
 {
 
-    enum MergerModes
+    enum MergerMode
     {
         DAMergerCallback,
         DAMergerAdvancedList
@@ -50,8 +50,8 @@ namespace Heaven
         DynamicActionMerger( QObject* parent );
 
     public:
-        void setMode( MergerModes mode );
-        MergerModes mode() const;
+        void setMode( MergerMode mode );
+        MergerMode mode() const;
 
     signals:
         void entryTriggered( const QVariant& value );

--- a/src/libHeaven/Actions/DynamicActionMerger.hpp
+++ b/src/libHeaven/Actions/DynamicActionMerger.hpp
@@ -31,7 +31,6 @@ namespace Heaven
     enum MergerModes
     {
         DAMergerCallback,
-        DAMergerStringList,
         DAMergerAdvancedList
     };
 
@@ -41,8 +40,11 @@ namespace Heaven
         DAMergerActionMergerControlled
     };
 
+    class DynamicActionMergerPrivate;
+
     class HEAVEN_API DynamicActionMerger : public UiObject
     {
+        friend class DynamicActionMergerPrivate;
         Q_OBJECT
     public:
         DynamicActionMerger( QObject* parent );
@@ -51,18 +53,14 @@ namespace Heaven
         void setMode( MergerModes mode );
         MergerModes mode() const;
 
-    public:
-        void setStringList( const QStringList& list );
-        QStringList& stringList() const;
-
-    public:
-        void addAdvancedEntry( const QString& display, const QVariant& value );
-        void addAdvancedSeparator();
-
     signals:
         void entryTriggered( const QVariant& value );
 
     public:
+        void clear();
+        void addStringList( const QStringList& list );
+        void addSeparator();
+        void addAction( const QString& display, const QVariant& value );
         void addAction( QAction* act, const QVariant& value = QVariant(),
                         MergerActionLifetime lifeTime = DAMergerActionUserControlled );
 

--- a/src/libHeaven/Actions/DynamicActionMerger.hpp
+++ b/src/libHeaven/Actions/DynamicActionMerger.hpp
@@ -1,6 +1,8 @@
 /*
  * libHeaven - A Qt-based ui framework for strongly modularized applications
- * Copyright (C) 2012-2013 Sascha Cunz <sascha@babbelbox.org>
+ * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ *
+ * (C) Sascha Cunz <sascha@macgitver.org>
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License (Version 2) as published by the Free Software Foundation.

--- a/src/libHeaven/Actions/DynamicActionMerger.hpp
+++ b/src/libHeaven/Actions/DynamicActionMerger.hpp
@@ -18,6 +18,7 @@
 #define MGV_HEAVEN_DYNAMIC_ACTION_MERGER_HPP
 
 #include <QString>
+#include <QVariant>
 #include <QObject>
 
 #include "libHeaven/Actions/UiObject.hpp"
@@ -27,6 +28,19 @@ class QAction;
 namespace Heaven
 {
 
+    enum MergerModes
+    {
+        DAMergerCallback,
+        DAMergerStringList,
+        DAMergerAdvancedList
+    };
+
+    enum MergerActionLifetime
+    {
+        DAMergerActionUserControlled,
+        DAMergerActionMergerControlled
+    };
+
     class HEAVEN_API DynamicActionMerger : public UiObject
     {
         Q_OBJECT
@@ -34,7 +48,23 @@ namespace Heaven
         DynamicActionMerger( QObject* parent );
 
     public:
-        void addAction( QAction* act );
+        void setMode( MergerModes mode );
+        MergerModes mode() const;
+
+    public:
+        void setStringList( const QStringList& list );
+        QStringList& stringList() const;
+
+    public:
+        void addAdvancedEntry( const QString& display, const QVariant& value );
+        void addAdvancedSeparator();
+
+    signals:
+        void entryTriggered( const QVariant& value );
+
+    public:
+        void addAction( QAction* act, const QVariant& value = QVariant(),
+                        MergerActionLifetime lifeTime = DAMergerActionUserControlled );
 
     public slots:
         void triggerRebuild();

--- a/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
+++ b/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
@@ -53,7 +53,7 @@ namespace Heaven
     public:
         QByteArray                  mMergerSlot;
         QList< ActionListEntry >    mActions;
-        MergerModes                 mMode;
+        MergerMode                  mMode;
     };
 
 }

--- a/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
+++ b/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
@@ -1,6 +1,8 @@
 /*
  * libHeaven - A Qt-based ui framework for strongly modularized applications
- * Copyright (C) 2012-2013 Sascha Cunz <sascha@babbelbox.org>
+ * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ *
+ * (C) Sascha Cunz <sascha@macgitver.org>
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the
  * GNU General Public License (Version 2) as published by the Free Software Foundation.

--- a/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
+++ b/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
@@ -29,8 +29,19 @@ namespace Heaven
     {
         Q_OBJECT
     public:
+        struct ActionListEntry
+        {
+            QAction*                mAction;
+            MergerActionLifetime    mLifetime;
+            QVariant                mValue;
+        };
+
+    public:
         DynamicActionMergerPrivate( DynamicActionMerger* owner );
         ~DynamicActionMergerPrivate();
+
+    private:
+        void freeActionList();
 
     public:
         UiObjectTypes type() const;
@@ -39,8 +50,9 @@ namespace Heaven
         void addActionsTo( QWidget* widget );
 
     public:
-        QByteArray mMergerSlot;
-        QList< QAction* > mActions;
+        QByteArray                  mMergerSlot;
+        QList< ActionListEntry >    mActions;
+        MergerModes                 mMode;
     };
 
 }

--- a/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
+++ b/src/libHeaven/Actions/DynamicActionMergerPrivate.hpp
@@ -40,14 +40,15 @@ namespace Heaven
         DynamicActionMergerPrivate( DynamicActionMerger* owner );
         ~DynamicActionMergerPrivate();
 
-    private:
-        void freeActionList();
-
     public:
         UiObjectTypes type() const;
 
     public:
+        void freeActionList();
         void addActionsTo( QWidget* widget );
+
+    private slots:
+        void onActionTriggered();
 
     public:
         QByteArray                  mMergerSlot;


### PR DESCRIPTION
Up to now, the dynamic action merger interface is only able to call back to the consumer code when the internal menu structure has to be rebuild.
This patchset adds another mode to the DAM interface, so that it is possible to register actions with the DAM or simple set a list with mappings from "Display" to "Variant", from which the DAM will internally create `QAction` objects and handle their triggering; resulting in a single emitted signal that has the Variant as parameter.
