### PR TITLE
Initial version of Views-Menu

### DIFF
--- a/src/libHeaven/CMakeLists.txt
+++ b/src/libHeaven/CMakeLists.txt
@@ -67,6 +67,7 @@ SET( SRC_FILES
     CentralUI/Views/View.cpp
     CentralUI/Views/AbstractViewWidget.cpp
     CentralUI/Views/ViewDescriptor.cpp
+    CentralUI/Views/ViewDescriptorRegistrar.cpp
     CentralUI/Views/ViewIdentifier.cpp
 
     CentralUI/Contexts/ContextKeys.cpp
@@ -202,6 +203,8 @@ SET( PRI_HDR_FILES
     CentralUI/States/WindowStateView.hpp
     CentralUI/States/WindowStateWindow.hpp
 
+    CentralUI/Views/ViewDescriptorRegistrar.hpp
+
     Widgets/FooterWidget.hpp
     Widgets/ModeSwitchCombo.hpp
     Widgets/TabWidget.hpp
@@ -217,6 +220,7 @@ SET( RCC_FILES
 )
 
 SET( HID_FILES
+    CentralUI/Views/ViewsMergerActions.hid
     CentralUI/ContainerWidgets/MultiBarContainerWidgetActions.hid
     MultiBar/MultiBarViewWidgetActions.hid
 )

--- a/src/libHeaven/CentralUI/Views/View.cpp
+++ b/src/libHeaven/CentralUI/Views/View.cpp
@@ -18,6 +18,7 @@
 #include <QVBoxLayout>
 
 #include "libHeaven/CentralUI/Views/View.hpp"
+#include "libHeaven/CentralUI/Views/ViewDescriptorRegistrar.hpp"
 #include "libHeaven/CentralUI/Contexts/ViewContextManager.hpp"
 
 namespace Heaven
@@ -152,6 +153,8 @@ namespace Heaven
      */
     void View::closeView()
     {
+        ViewDescriptor::Registrar::self().viewClosed(this);
+
         parentContainer()->take( this );
 
         deleteLater();

--- a/src/libHeaven/CentralUI/Views/ViewDescriptor.hpp
+++ b/src/libHeaven/CentralUI/Views/ViewDescriptor.hpp
@@ -19,24 +19,34 @@
 #ifndef HEAVEN_VIEW_DESCRIPTOR_HPP
 #define HEAVEN_VIEW_DESCRIPTOR_HPP
 
+#include <QObject>
+
 #include "libHeaven/HeavenApi.hpp"
 
 #include "libHeaven/CentralUI/Views/ViewIdentifier.hpp"
 
+class QAction;
+
 namespace Heaven
 {
 
+    class DynamicActionMerger;
     class View;
 
-    class HEAVEN_API ViewDescriptor
+    class HEAVEN_API ViewDescriptor : public QObject
     {
+        Q_OBJECT
     public:
+        class Registrar;
+        friend class Registrar;
         typedef View* (*CreatorFunc)( );
 
     public:
-        ViewDescriptor( const ViewIdentifier& id, const QString& displayName, CreatorFunc creator );
+        ViewDescriptor(const ViewIdentifier& id, const QString& displayName, CreatorFunc creator);
+        ~ViewDescriptor();
 
     public:
+        QAction* activatorAction();
         QString displayName() const;
         ViewIdentifier identifier() const;
         ViewDescriptor::CreatorFunc creatorFunc() const;
@@ -45,13 +55,23 @@ namespace Heaven
         View* createView() const;
 
     public:
+        static DynamicActionMerger* actionMerger();
+        static void mergeViewsMenu(const QByteArray& mergePlace);
         static ViewDescriptor* get( const ViewIdentifier& id );
+
+    private:
+        void setViewClosed();
+        void createActivatorAction();
+
+    private slots:
+        void onActivatorAction(bool triggered);
 
     private:
         const ViewIdentifier    mIdentifier;
         const QString           mDisplayName;
         const CreatorFunc       mCreatorFunc;
-        static QHash< ViewIdentifier, ViewDescriptor* > mDescriptors;
+        mutable View*           mCreatedView;
+        QAction*                mActivatorAction;
     };
 
 }

--- a/src/libHeaven/CentralUI/Views/ViewDescriptorRegistrar.cpp
+++ b/src/libHeaven/CentralUI/Views/ViewDescriptorRegistrar.cpp
@@ -1,0 +1,120 @@
+/*
+ * libHeaven - A Qt-based ui framework for strongly modularized applications
+ * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ *
+ * (C) Sascha Cunz <sascha@macgitver.org>
+ * (C) Cunz RaD Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QAction>
+
+#include "libHeaven/Actions/DynamicActionMerger.hpp"
+
+#include "View.hpp"
+#include "ViewDescriptorRegistrar.hpp"
+
+namespace Heaven
+{
+
+    /**
+     * @internal
+     * @class       ViewDescriptor::Registrar
+     *
+     * @brief       Internal class to manage registered ViewDescriptors and the Views-Menu
+     *
+     */
+
+    ViewDescriptor::Registrar::Registrar()
+    {
+        setupActions(this);
+        damViewsMerger->setMode(DAMergerAdvancedList);
+        sSelf = this;
+    }
+
+    ViewDescriptor::Registrar& ViewDescriptor::Registrar::self()
+    {
+        if (sSelf == NULL) {
+            new Registrar();
+        }
+        return *sSelf;
+    }
+
+    ViewDescriptor::Registrar* ViewDescriptor::Registrar::sSelf = NULL;
+
+    void ViewDescriptor::Registrar::insert(const ViewIdentifier& id, ViewDescriptor* vd)
+    {
+        mDescriptors.insert(id, vd);
+        rebuildMerger();
+    }
+
+    void ViewDescriptor::Registrar::remove(const ViewIdentifier& id)
+    {
+        mDescriptors.remove(id);
+        rebuildMerger();
+    }
+
+    ViewDescriptor* ViewDescriptor::Registrar::get(const ViewIdentifier& id) const
+    {
+        return mDescriptors.value(id, NULL);
+    }
+
+    void ViewDescriptor::Registrar::viewClosed(View* view)
+    {
+        ViewIdentifier id = view->identifier();
+        ViewDescriptor* vd = get(id);
+
+        if (vd) {
+            QAction* aa = vd->activatorAction();
+            aa->setChecked(false);
+
+            vd->setViewClosed();
+        }
+    }
+
+    void ViewDescriptor::Registrar::viewOpened(View* view)
+    {
+        ViewIdentifier id = view->identifier();
+        ViewDescriptor* vd = get(id);
+
+        if (vd) {
+            QAction* aa = vd->activatorAction();
+            aa->setChecked(true);
+        }
+    }
+
+    DynamicActionMerger* ViewDescriptor::Registrar::actionMerger()
+    {
+        return damViewsMerger;
+    }
+
+    void ViewDescriptor::Registrar::rebuildMerger()
+    {
+        Q_ASSERT(damViewsMerger);
+        damViewsMerger->clear();
+
+        QMap<ViewIdentifier, ViewDescriptor*> descriptors;
+
+        foreach (ViewIdentifier id, mDescriptors.keys()) {
+            descriptors.insert(id, mDescriptors[id]);
+        }
+
+        foreach (ViewIdentifier id, descriptors.keys()) {
+            ViewDescriptor* vd = get(id);
+            if (vd) {
+                damViewsMerger->addAction(vd->activatorAction());
+            }
+        }
+    }
+
+}

--- a/src/libHeaven/CentralUI/Views/ViewDescriptorRegistrar.hpp
+++ b/src/libHeaven/CentralUI/Views/ViewDescriptorRegistrar.hpp
@@ -1,0 +1,63 @@
+/*
+ * libHeaven - A Qt-based ui framework for strongly modularized applications
+ * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ *
+ * (C) Sascha Cunz <sascha@macgitver.org>
+ * (C) Cunz RaD Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HEAVEN_VIEW_DESCRIPTOR_REGISTRAR_HPP
+#define HEAVEN_VIEW_DESCRIPTOR_REGISTRAR_HPP
+
+#include <QHash>
+#include <QObject>
+
+#include "ViewIdentifier.hpp"
+#include "ViewDescriptor.hpp"
+
+#include "hic_ViewsMergerActions.h"
+
+namespace Heaven
+{
+
+    class ViewDescriptor::Registrar : public QObject, public ViewsMergerActions
+    {
+        Q_OBJECT
+    private:
+        Registrar();
+        static Registrar* sSelf;
+
+    public:
+        static Registrar& self();
+
+    public:
+        void remove(const ViewIdentifier& id);
+        void insert(const ViewIdentifier& id, ViewDescriptor* vd);
+        ViewDescriptor* get(const ViewIdentifier& id) const;
+
+        void viewClosed(View* view);
+        void viewOpened(View* view);
+
+        DynamicActionMerger* actionMerger();
+
+    private:
+        void rebuildMerger();
+
+    private:
+        QHash< ViewIdentifier, ViewDescriptor* > mDescriptors;
+    };
+
+}
+
+#endif

--- a/src/libHeaven/CentralUI/Views/ViewIdentifier.cpp
+++ b/src/libHeaven/CentralUI/Views/ViewIdentifier.cpp
@@ -16,6 +16,9 @@
  *
  */
 
+#include <QDebug>
+#include <QStringBuilder>
+
 #include "libHeaven/CentralUI/Views/ViewIdentifier.hpp"
 
 namespace Heaven
@@ -220,4 +223,47 @@ namespace Heaven
         return !mName.isEmpty();
     }
 
+    /**
+     * @brief       Hashing function for ViewIdentifiers
+     *
+     * @param[in]   id  The identifier to hash
+     *
+     * @return      a hash suitable for QHash template
+     *
+     */
+    uint qHash(const ViewIdentifier& id)
+    {
+        return qHash(id.toString());
+    }
+
+    /**
+     * @brief       Compare two ViewIdentifiers (less than)
+     *
+     * @param[in]   lhs     Left hand side to compare
+     * @param[in]   rhs     Right hand side to compare
+     *
+     * @return      `true` if left is smaller than right
+     *
+     */
+    bool operator<(const ViewIdentifier& lhs, const ViewIdentifier& rhs)
+    {
+        return lhs.toString() < rhs.toString();
+    }
+
+}
+
+/**
+ * @brief       QDebug Shift operator for ViewIdentifier
+ *
+ * @param[in]   stream      The debug stream to shift into
+ *
+ * @param[in]   id          The ViewIdentifier to output
+ *
+ * @return      A reference to @a stream.
+ *
+ */
+QDebug& operator<<(QDebug& stream, const Heaven::ViewIdentifier& id)
+{
+    QString s = QLatin1Literal("(VId:") % id.toString() % QChar(L')');
+    return stream << qPrintable(s);
 }

--- a/src/libHeaven/CentralUI/Views/ViewIdentifier.hpp
+++ b/src/libHeaven/CentralUI/Views/ViewIdentifier.hpp
@@ -20,7 +20,6 @@
 #define HEAVEN_VIEW_IDENTIFIER_HPP
 
 #include <QString>
-#include <QHash>
 
 #include "libHeaven/HeavenApi.hpp"
 
@@ -53,11 +52,12 @@ namespace Heaven
         QString mName;
     };
 
-    inline uint qHash( const ViewIdentifier& id )
-    {
-        return qHash( id.toString() );
-    }
+    HEAVEN_API uint qHash( const ViewIdentifier& id );
+
+    HEAVEN_API bool operator<(const ViewIdentifier& lhs, const ViewIdentifier& rhs);
 
 }
+
+HEAVEN_API QDebug& operator<<(QDebug& stream, const Heaven::ViewIdentifier& id);
 
 #endif

--- a/src/libHeaven/CentralUI/Views/ViewsMergerActions.hid
+++ b/src/libHeaven/CentralUI/Views/ViewsMergerActions.hid
@@ -1,0 +1,30 @@
+/*
+ * libHeaven - A Qt-based ui framework for strongly modularized applications
+ * Copyright (C) 2012-2013 The MacGitver-Developers <dev@macgitver.org>
+ *
+ * (C) Sascha Cunz <sascha@macgitver.org>
+ * (C) Cunz RaD Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+Ui ViewsMergerActions {
+
+    Container ViewsMergerAC {
+
+        DynamicActionMerger ViewsMerger {
+
+        };
+
+    };
+
+};


### PR DESCRIPTION
This is the rivalling change for #18. Looking at it, it might be more a prerequisite. I don't think they will clash, but this one isn't fully finished yet.

What this does, is: Split the `Heaven::ViewDescriptor` into 2 classes. One of them is private and does the descriptor management now. It additionally keeps a checkable `QAction` for every view. This action is checked when the view is visible and unchecked when not. When the user unchecks the action, the view is closed.

Missing is still: When the user checks the action, the view shall appear. But actually, this requires some more work than I initially thought. So I'm probably again deferring a part of a libHeaven task for later.

@antis81 I think, that libHeaven has become an unloved stepchild of mgv lastly. Partially I have problems to remember what work I have begun and what is still completely not started. Add to that that the most concepts of libHeaven are (at least internally) very hard to grasp...
