### PR TITLE
Changed pointer types to base class

### DIFF
--- a/libBlueSky/Application.cpp
+++ b/libBlueSky/Application.cpp
@@ -49,7 +49,7 @@ namespace BlueSky {
 
         bool mModeReorderQueued;
 
-        Internal::XmlStateRoot::Ptr mModelessFakeState;
+        Internal::XmlState::Ptr mModelessFakeState;
     };
 
     Application::Private::Private(Application* owner)
@@ -181,7 +181,7 @@ namespace BlueSky {
 
     void Application::forceModeSwitch() {
 
-        Internal::XmlStateRoot::Ptr state = d->mModelessFakeState;
+        Internal::XmlState::Ptr state = d->mModelessFakeState;
 
         if (d->mActiveMode) {
             state = d->mActiveMode->currentState();

--- a/libBlueSky/Internal/XmlState.cpp
+++ b/libBlueSky/Internal/XmlState.cpp
@@ -484,7 +484,7 @@ namespace BlueSky {
          *
          * @param[in]   state   The WindowStateRoot to synchronize the current user interface to
          */
-        ModeSwitcher::ModeSwitcher(XmlStateRoot::Ptr state)
+        ModeSwitcher::ModeSwitcher(XmlState::Ptr state)
             : mState( state )
         {
         }

--- a/libBlueSky/Internal/XmlState.hpp
+++ b/libBlueSky/Internal/XmlState.hpp
@@ -192,7 +192,7 @@ namespace BlueSky {
         class ModeSwitcher
         {
         public:
-            ModeSwitcher(XmlStateRoot::Ptr state);
+            ModeSwitcher(XmlState::Ptr state);
 
         public:
             void run();
@@ -214,7 +214,7 @@ namespace BlueSky {
             void associateViewContainer(AbstractViewWidget* view, XmlState* wsView);
 
         private:
-            XmlStateRoot::Ptr    mState;
+            XmlState::Ptr    mState;
 
             QHash< ViewIdentifier, QPointer<View> > mExistingViews;
             QHash< ViewIdentifier, QPointer<ContainerWidget> > mExistingContainers;

--- a/libBlueSky/Mode.cpp
+++ b/libBlueSky/Mode.cpp
@@ -47,8 +47,8 @@ namespace BlueSky {
         QString                     mName;
         QByteArray                  mIdentifier;
 
-        Internal::XmlStateRoot::Ptr mDefaultState;
-        Internal::XmlStateRoot::Ptr mCurrentState;
+        Internal::XmlState::Ptr mDefaultState;
+        Internal::XmlState::Ptr mCurrentState;
 
         bool                        mEnabled        : 1;
         bool                        mExclusive      : 1;
@@ -135,7 +135,7 @@ namespace BlueSky {
         }
     }
 
-    Internal::XmlStateRoot::Ptr Mode::currentState() const {
+    Internal::XmlState::Ptr Mode::currentState() const {
 
         if (!d->mCurrentState) {
             if (d->mDefaultState) {
@@ -180,10 +180,10 @@ namespace BlueSky {
                 }
 
                 if (isDefault) {
-                    d->mDefaultState = static_cast<Internal::XmlStateRoot *>( xmlState.data() );
+                    d->mDefaultState = xmlState;
                 }
 
-                d->mCurrentState = static_cast<Internal::XmlStateRoot *>( xmlState.data() );
+                d->mCurrentState = xmlState;
             }
             else {
                 qDebug() << "Unknown tag:" << name;
@@ -200,7 +200,7 @@ namespace BlueSky {
 
     void Mode::setup() {
         QString state = createDefaultState();
-        d->mDefaultState = static_cast<Internal::XmlStateRoot *>( Internal::XmlState::read(state).data() );
+        d->mDefaultState = Internal::XmlState::read(state);
     }
 
     namespace Internal {

--- a/libBlueSky/Mode.hpp
+++ b/libBlueSky/Mode.hpp
@@ -33,6 +33,7 @@ namespace BlueSky {
     class Frame;
 
     namespace Internal {
+        class XmlState;
         class XmlStateRoot;
     }
 
@@ -55,7 +56,7 @@ namespace BlueSky {
         bool isExclusive() const;
         bool isHidden() const;
 
-        QExplicitlySharedDataPointer<Internal::XmlStateRoot> currentState() const;
+        QExplicitlySharedDataPointer<Internal::XmlState> currentState() const;
 
     public slots:
         void setDisplayOrder(int order);


### PR DESCRIPTION
Changed pointer type from `Internal::XmlStateRoot` to `Internal::XmlState`.

@scunz Can you please verify, this is ok?
