### PR TITLE
feature: pinned dialog

### DIFF
--- a/Tester/MainWindow.cpp
+++ b/Tester/MainWindow.cpp
@@ -15,6 +15,9 @@
  */
 
 #include <QApplication>
+#include <QDialogButtonBox>
+#include <QDebug>
+#include <QLabel>
 #include <QVBoxLayout>
 
 #include "libBlueSky/Dialog.hpp"
@@ -49,5 +52,55 @@ void MainWindow::settingsColors() {
     d->setLayout(l);
     l->addWidget(Heaven::ColorManager::self().createEditorWidget());
 
+    // a heavenly size grip for testing
+    d->setResizerEnabled(true);
+
     d->exec();
+}
+
+void MainWindow::showPinnedDialog()
+{
+    BlueSky::Dialog *dlg = new BlueSky::Dialog;
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->setResizerEnabled(true);
+
+    QVBoxLayout* l = new QVBoxLayout;
+    dlg->setLayout(l);
+
+    QLabel* sampleText =
+            new QLabel(
+                QStringLiteral("<html><head><style>"
+                               "h1 {color: #ea5}"
+                               "pre {margin: 10px; background: #333; color: #fed; font: monospace 13pt;}"
+                               "</style></head><body>"
+                               "<h1>Pinned Dialog Example</h1>"
+                               "<p>"
+                               "This is a sample for a libHeaven pinned Dialog."
+                               "<br/><br/>A pinned dalog is created like this:"
+                               "<pre lang='c++'`>"
+                               "BlueSky::Dialog *dlg = new BlueSky::Dialog;"
+                               "\ndlg->setAttribute(Qt::WA_DeleteOnClose);"
+                               "\n// setup the dialog contents here"
+                               "\ndlg->open();\n_"
+                               "</pre></p></body></html>"
+                               ));
+    l->addWidget(sampleText);
+    QDialogButtonBox* buttons = new QDialogButtonBox(QDialogButtonBox::Close);
+    connect(buttons, &QDialogButtonBox::rejected, dlg, &BlueSky::Dialog::reject);
+    l->addWidget(buttons);
+
+    dlg->setStyleSheet(QLatin1Literal("QLabel{ border: 1px dotted gray; background: #eef; }"));
+
+    dlg->open();
+
+    // some output for testing
+    const QPoint absPos = dlg->frameGeometry().topLeft();
+    qDebug() << "Pinned Dialog:"
+             << "\n  - parentWidget == this:\t" << (dlg->parentWidget() == this)
+             << "\n  - modality:\t" << dlg->windowModality()
+             << "\n  - isModal:\t" << dlg->isModal()
+             << "\n  - abs. positiion:\t"   << absPos
+             << "\n  - rel. position:\t"    << mapFromParent(absPos)
+             << "\n  - size:\t"             << dlg->size()
+                ;
 }

--- a/Tester/MainWindow.hpp
+++ b/Tester/MainWindow.hpp
@@ -32,6 +32,7 @@ public:
 private slots:
     void quit();
     void settingsColors();
+    void showPinnedDialog();
 };
 
 #endif

--- a/Tester/MainWindowActions.hid
+++ b/Tester/MainWindowActions.hid
@@ -38,6 +38,15 @@ Ui MainWindowActions {
             };
         };
 
+        Menu Dialogs {
+            Text "&Dialogs";
+
+            Action actDialogs {
+                Text "&Pinned Dialog";
+                ConnectTo showPinnedDialog();
+            };
+        };
+
     };
 
 };

--- a/libBlueSky/CMakeLists.txt
+++ b/libBlueSky/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(SRC_FILES
     Contexts.cpp
     Style.cpp
     Dialog.cpp
+    SizeGrip.cpp
 
     Internal/MultiBar.cpp
     Internal/ViewRegistrar.cpp
@@ -38,6 +39,7 @@ SET(HDR_PUB_FILES
     Style.hpp
     Contexts.hpp
     Dialog.hpp
+    SizeGrip.hpp
 )
 
 SET(HDR_PRI_FILES

--- a/libBlueSky/SizeGrip.cpp
+++ b/libBlueSky/SizeGrip.cpp
@@ -1,0 +1,204 @@
+/*
+ * libHeaven - A Qt-based ui framework for strongly modularized applications
+ * Copyright (C) 2012-2015 Cunz RAD Ltd.
+ *
+ * (C) Nils Fenner <nils@macgitver.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "SizeGrip.hpp"
+
+#include <QAbstractScrollArea>
+#include <QApplication>
+#include <QDesktopWidget>
+#include <QLayout>
+#include <QMouseEvent>
+
+namespace BlueSky {
+
+SizeGrip::SizeGrip(QWidget* parent)
+    : QSizeGrip(parent)
+    , mResizeDirections(ResizeDefault)
+    , mParentWindow(parent)
+    , mGotMousePress(false)
+    , dxMax(0)
+    , dyMax(0)
+    , mCorner(mParentWindow->isLeftToRight() ? Qt::BottomRightCorner : Qt::BottomLeftCorner)
+{
+    Q_ASSERT(parent);
+    resize(sizeHint());
+}
+
+SizeGrip::ResizeDirections SizeGrip::resizeBehaviour() const
+{
+    return mResizeDirections;
+}
+
+void SizeGrip::setResizeBehaviour(int behaviour)
+{
+    mResizeDirections = static_cast<ResizeDirections>(behaviour);
+}
+
+void SizeGrip::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) {
+        QWidget::mousePressEvent(ev);
+        return;
+    }
+
+    QWidget *tlw = mParentWindow;
+    mGotMousePress = true;
+    mStartPos = ev->globalPos();
+    mDlgRect = mParentWindow->geometry();
+
+    // TODO: The following requires QPA stuff and we don't have access here
+    // Does the platform provide size grip support?
+//    m_platformSizeGrip = false;
+//    if (tlw->isWindow()
+//        && tlw->windowHandle()
+//        && !(tlw->windowFlags() & Qt::X11BypassWindowManagerHint)
+//        && !tlw->testAttribute(Qt::WA_DontShowOnScreen)
+//        && !tlw->hasHeightForWidth()) {
+//        QPlatformWindow *platformWindow = tlw->windowHandle()->handle();
+//        const QPoint topLevelPos = mapTo(tlw, ev->pos());
+//        m_platformSizeGrip = platformWindow && platformWindow->startSystemResize(topLevelPos, mCorner);
+//    }
+
+//    if (m_platformSizeGrip)
+//        return;
+
+    // Find available desktop/workspace geometry.
+    QRect availableGeometry;
+    bool hasVerticalSizeConstraint = true;
+    bool hasHorizontalSizeConstraint = true;
+    if (tlw->isWindow())
+        availableGeometry = QApplication::desktop()->availableGeometry(tlw);
+    else {
+        const QWidget *tlwParent = tlw->parentWidget();
+        // Check if tlw is inside QAbstractScrollArea/QScrollArea.
+        // If that's the case tlw->parentWidget() will return the viewport
+        // and tlw->parentWidget()->parentWidget() will return the scroll area.
+#ifndef QT_NO_SCROLLAREA
+        QAbstractScrollArea *scrollArea = qobject_cast<QAbstractScrollArea *>(tlwParent->parentWidget());
+        if (scrollArea) {
+            hasHorizontalSizeConstraint = scrollArea->horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff;
+            hasVerticalSizeConstraint = scrollArea->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff;
+        }
+#endif
+        availableGeometry = tlwParent->contentsRect();
+    }
+
+    // Find frame geometries, title bar height, and decoration sizes.
+    const QRect frameGeometry = tlw->frameGeometry();
+    const int titleBarHeight = qMax(tlw->geometry().y() - frameGeometry.y(), 0);
+    const int bottomDecoration = qMax(frameGeometry.height() - tlw->height() - titleBarHeight, 0);
+    const int leftRightDecoration = qMax((frameGeometry.width() - tlw->width()) / 2, 0);
+
+    // Determine dyMax depending on whether the sizegrip is at the bottom
+    // of the widget or not.
+    if (atBottom()) {
+        if (hasVerticalSizeConstraint)
+            dyMax = availableGeometry.bottom() - mDlgRect.bottom() - bottomDecoration;
+        else
+            dyMax = INT_MAX;
+    } else {
+        if (hasVerticalSizeConstraint)
+            dyMax = availableGeometry.y() - mDlgRect.y() + titleBarHeight;
+        else
+            dyMax = -INT_MAX;
+    }
+
+    // In RTL mode, the size grip is to the left; find dxMax from the desktop/workspace
+    // geometry, the size grip geometry and the width of the decoration.
+    if (atLeft()) {
+        if (hasHorizontalSizeConstraint)
+            dxMax = availableGeometry.x() - mDlgRect.x() + leftRightDecoration;
+        else
+            dxMax = -INT_MAX;
+    } else {
+        if (hasHorizontalSizeConstraint)
+            dxMax = availableGeometry.right() - mDlgRect.right() - leftRightDecoration;
+        else
+            dxMax = INT_MAX;
+    }
+}
+
+void SizeGrip::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        mGotMousePress = false;
+        mStartPos = QPoint();
+    }
+
+    QSizeGrip::mouseReleaseEvent(ev);
+}
+
+void SizeGrip::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (ev->buttons() != Qt::LeftButton) {
+        QWidget::mouseMoveEvent(ev);
+        return;
+    }
+
+    QWidget* tlw = mParentWindow;
+
+    if (!mGotMousePress || tlw->testAttribute(Qt::WA_WState_ConfigPending)) {
+        return;
+    }
+
+
+    QPoint np(ev->globalPos());
+
+    const int dx        = np.x() - mStartPos.x();
+    const int dx2       = mResizeDirections.testFlag(ResizeMirrorHorizontal) ? dx * 2    : dx;
+    const int dxMax2    = mResizeDirections.testFlag(ResizeMirrorHorizontal) ? dxMax * 2 : dxMax;
+    const int dy        = np.y() - mStartPos.y();
+    const int dy2       = mResizeDirections.testFlag(ResizeMirrorVertical) ? dy * 2    : dy;
+    const int dyMax2    = mResizeDirections.testFlag(ResizeMirrorVertical) ? dyMax * 2 : dyMax;
+
+    // Don't extend beyond the available geometry; bound to dyMax and dxMax.
+    QSize ns(atLeft()   ? mDlgRect.width() - qMax(dx2, dxMax2)
+                        : mDlgRect.width() + qMin(dx2, dxMax2),
+             atBottom() ? mDlgRect.height() + qMin(dy2, dyMax2)
+                        : mDlgRect.height() - qMax(dy2, dyMax2));
+
+    ns = QLayout::closestAcceptableSize(tlw, ns);
+
+    QPoint p;
+    QRect nr(p, ns);
+    if (atBottom()) {
+        nr.moveTop(mResizeDirections.testFlag(ResizeMirrorVertical)
+                   ? qMin(mDlgRect.top(), mDlgRect.top() - qMin(dy, dyMax))
+                   : mDlgRect.top());
+    }
+    else {
+        nr.moveBottom(mResizeDirections.testFlag(ResizeMirrorVertical)
+                      ? qMax(mDlgRect.bottom(), mDlgRect.bottom() - qMax(dy, dyMax))
+                      : mDlgRect.bottom());
+    }
+
+    if (atLeft()) {
+        nr.moveRight(mResizeDirections.testFlag(ResizeMirrorHorizontal)
+                     ? qMax(mDlgRect.right(), mDlgRect.right() - qMax(dx, dxMax))
+                     : mDlgRect.right());
+    }
+    else {
+        nr.moveLeft(mResizeDirections.testFlag(ResizeMirrorHorizontal)
+                    ? qMin(mDlgRect.left(), mDlgRect.left() - qMin(dx, dxMax))
+                    : mDlgRect.left());
+    }
+
+    tlw->setGeometry(nr);
+}
+
+}

--- a/libBlueSky/SizeGrip.hpp
+++ b/libBlueSky/SizeGrip.hpp
@@ -1,0 +1,79 @@
+/*
+ * libHeaven - A Qt-based ui framework for strongly modularized applications
+ * Copyright (C) 2012-2015 Cunz RAD Ltd.
+ *
+ * (C) Nils Fenner <nils@macgitver.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License (Version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "libBlueSky/libBlueSkyAPI.hpp"
+
+#include <QSizeGrip>
+
+namespace BlueSky {
+
+    class HEAVEN_BLUESKY_API SizeGrip
+            : public QSizeGrip
+    {
+    public:
+        enum ResizeBehaviour {
+            ResizeDefault             = 0x00,
+            ResizeMirrorHorizontal    = 0x01,
+            ResizeMirrorVertical      = 0x02
+        };
+        Q_DECLARE_FLAGS(ResizeDirections, ResizeBehaviour);
+
+    public:
+        explicit SizeGrip(QWidget* parent);
+
+    public:
+        ResizeDirections resizeBehaviour() const;
+        void setResizeBehaviour(int behaviour);
+
+    public:
+        inline bool atBottom() const
+        {
+            return mCorner == Qt::BottomRightCorner || mCorner == Qt::BottomLeftCorner;
+        }
+
+        inline bool atLeft() const
+        {
+            return mCorner == Qt::BottomLeftCorner || mCorner == Qt::TopLeftCorner;
+        }
+
+        inline void updatePos()
+        {
+            move(mParentWindow->isLeftToRight() ? mParentWindow->rect().bottomRight() - rect().bottomRight()
+                                             : mParentWindow->rect().bottomLeft() - rect().bottomLeft());
+        }
+
+    private:
+        void mousePressEvent(QMouseEvent* ev) Q_DECL_OVERRIDE;
+        void mouseReleaseEvent(QMouseEvent* ev) Q_DECL_OVERRIDE;
+        void mouseMoveEvent(QMouseEvent * ev) Q_DECL_OVERRIDE;
+
+    private:
+        ResizeDirections    mResizeDirections;
+
+        QWidget*    mParentWindow;
+        bool        mGotMousePress;
+        QPoint      mStartPos;
+        int         dxMax;
+        int         dyMax;
+        QRect       mDlgRect;
+        Qt::Corner  mCorner;
+    };
+
+}


### PR DESCRIPTION
:warning: _Do not merge this PR! We're working with PIB workflow!_

Usually Qt imitates the native "look & feel" of a desktop environment - which is totally well accomplished. We in `libHeaven` go a step further and provide concepts, a native platform doesn't provide. In this case, I got inspired by the OSX sheets concept and like to provide them for libHeaven based applications on each platform. We call that a `pinned dialog`.

There's some caveats, but the foundation is done and realized as a "usual" `BlueSky::Dialog`. Like shown in the `Tester` sample application, the dialog becomes "pinned" to a parent window's edge or corner through the `open()` method.

TODO's:
- [x] move the dialog together with the main window
  - **Note:** dialog will be moved after window reached target position - at least on X11
- [x] cancelled for this PR ~~align the dialog to the parent window (the `Qt::WindowFrameSection` fits well here)~~
- [x] If alignment is centered, the pinned dialog shall expand in both directions.
- [x] top-level should only apply to parent window (modality)
  - Deactivated `Qt::BypassWindowManagerHint` -> the dialog is not window-modal and can be left
- [x] Cancelled for this PR: ~~add a nice "falling" transition animation~~

Visual appearance in my Lubuntu 15.04:
![pinned-dialog-sample](https://cloud.githubusercontent.com/assets/440517/8742648/d33cd6ee-2c67-11e5-9dab-7f83b9a5b67b.png)

@scunz Could you give it a short test on OSX (requires your `Heaven::Tester` application)? These changes should not affect this platform at all!
